### PR TITLE
PDB signature fixes

### DIFF
--- a/symstore/pdb.py
+++ b/symstore/pdb.py
@@ -176,8 +176,9 @@ class PDBFile:
             _, _, age, guid_d1, guid_d2, guid_d3, guid_d4 = \
                 struct.unpack("<IIIIHH8s", f.read(4*4 + 2 * 2 + 8))
 
-            # load proper age from the DBI information (PDB information age changes when using PDBSTR)
-            # vc140.pdb however, does not have this stream, we'll use the regular age for that one
+            # load proper age from the DBI information (PDB information age
+            # changes when using PDBSTR) vc140.pdb however, does not have
+            # this stream, we'll use the regular age for that one
             dbi_stream_pages = root.stream_pages(3)
             if 0 < len(dbi_stream_pages):
                 f.seek(dbi_stream_pages[0]*page_size)

--- a/symstore/pdb.py
+++ b/symstore/pdb.py
@@ -168,11 +168,16 @@ class PDBFile:
 
             # load the PDB stream page
             pdb_stream_pages = root.stream_pages(1)
-            f.seek(pdb_stream_pages[0]*page_size)
 
-            # load age and GUID from PDB stream
-            _, _, age, guid_d1, guid_d2, guid_d3, guid_d4 = \
+            # load GUID from PDB stream
+            f.seek(pdb_stream_pages[0]*page_size)
+            _, _, _, guid_d1, guid_d2, guid_d3, guid_d4 = \
                 struct.unpack("<IIIIHH8s", f.read(4*4 + 2 * 2 + 8))
+
+            # load age from the DBI information (PDB information age changes when using PDBSTR)
+            dbi_stream_pages = root.stream_pages(3)
+            f.seek(dbi_stream_pages[0]*page_size)
+            _, _, age = struct.unpack("<III", f.read(3*4))
 
             # store GUID and age for user friendly retrieval
             self.guid = GUID(guid_d1, guid_d2, guid_d3, guid_d4)

--- a/symstore/pdb.py
+++ b/symstore/pdb.py
@@ -176,13 +176,15 @@ class PDBFile:
 
             # load GUID from PDB stream
             f.seek(pdb_stream_pages[0]*page_size)
-            _, _, _, guid_d1, guid_d2, guid_d3, guid_d4 = \
+            _, _, age, guid_d1, guid_d2, guid_d3, guid_d4 = \
                 struct.unpack("<IIIIHH8s", f.read(4*4 + 2 * 2 + 8))
 
-            # load age from the DBI information (PDB information age changes when using PDBSTR)
+            # load proper age from the DBI information (PDB information age changes when using PDBSTR)
+            # vc140.pdb however, does not have this stream, we'll use the regular age for that one
             dbi_stream_pages = root.stream_pages(3)
-            f.seek(dbi_stream_pages[0]*page_size)
-            _, _, age = struct.unpack("<III", f.read(3*4))
+            if 0 < len(dbi_stream_pages):
+                f.seek(dbi_stream_pages[0]*page_size)
+                _, _, age = struct.unpack("<III", f.read(3*4))
 
             # store GUID and age for user friendly retrieval
             self.guid = GUID(guid_d1, guid_d2, guid_d3, guid_d4)

--- a/symstore/pdb.py
+++ b/symstore/pdb.py
@@ -65,8 +65,6 @@ class Root:
 
         :return: root bytes as an bytes array
         """
-        assert length < self.page_size, \
-            "multi-page reads not supported"
 
         start_page = start // self.page_size
         start_byte = start % self.page_size
@@ -74,11 +72,18 @@ class Root:
         end = start + length - 1
         end_page = end // self.page_size
 
-        assert start_page == end_page, \
-            "reads spanning two pages not implemented"
-
         self._seek(start_page, start_byte)
-        return self.fp.read(length)
+
+        partial_size = min(length, self.page_size - start_byte)
+        result = self.fp.read(partial_size)
+        length -= partial_size
+        while 0 < length:
+            start_page += 1
+            self._seek(start_page, 0)
+            partial_size = min(self.page_size, length)
+            result += self.fp.read(partial_size)
+            length -= partial_size
+        return result
 
     def num_streams(self):
         """

--- a/symstore/pdb.py
+++ b/symstore/pdb.py
@@ -69,9 +69,6 @@ class Root:
         start_page = start // self.page_size
         start_byte = start % self.page_size
 
-        end = start + length - 1
-        end_page = end // self.page_size
-
         self._seek(start_page, start_byte)
 
         partial_size = min(length, self.page_size - start_byte)

--- a/symstore/symstore.py
+++ b/symstore/symstore.py
@@ -35,7 +35,7 @@ EXT_TYPES = dict(pdb=PDB_IMAGE,
 
 def _pdb_hash(filename):
     pdbfile = pdb.PDBFile(filename)
-    return "%s%s" % (pdbfile.guid, pdbfile.age)
+    return "%s%x" % (pdbfile.guid, pdbfile.age)
 
 
 def _pe_hash(file):


### PR DESCRIPTION
This commit fixes two issues with the PDB signature generation:

* the age field needs to be expressed as a hex number, not decimal
* the age field is actually the one from the DBI stream, not the PDB stream

To see the first one, compile a project about 10 times, then use symstore.exe to store the PDB in a symbol store. Note that the signature ends with "...a", not with "...10".

To see the second one, you need to modify the PDB after it is being created by the linker. In our build system, we do this by invoking PDBSTR. This tool embeds a lookup-table inside the PDB, which enables source-level debugging on any machine, automatically. When it embeds the lookup table inside the PDB, the PDB age gets incremented. However, symstore.exe still uses the linker-generated age. Also, when VisualStudio or WinDBG search for the PDB, they still search for the original age. Hence, the age that needs to be retrieved is not the one specified in the PDB header stream, but the one in the DBI header stream (stream #3).

The two remaining commits introduce multi-page reads for the streams (since the DBI stream can be quiet large, hence the page table could span multiple pages) and also a fallback to the PDB age, just in case the PDB does not have a DBI header at all (only saw this with vc140.pdb).