### PR TITLE
fix exception during gcab detection

### DIFF
--- a/symstore/cab.py
+++ b/symstore/cab.py
@@ -8,6 +8,8 @@ try:
     gi.require_version('GCab', '1.0')
     from gi.repository import GCab
     from gi.repository import Gio
+except ValueError as e:
+    compression_supported = False
 except ImportError as e:
     compression_supported = False
 


### PR DESCRIPTION
`gi.require_version('GCab', '1.0')` can raise `ValueError`.
Handle this exception in addition to `ImportError`.

Fixes #7. 