### PR TITLE
Explicitly seek to the end of history.txt to handle a Python 2 error

### DIFF
--- a/symstore/symstore.py
+++ b/symstore/symstore.py
@@ -330,7 +330,13 @@ class History:
                 return False
 
             f.seek(-1, os.SEEK_END)
-            return f.read() != b'\n'
+            ch = f.read(1)
+
+            # use seek() for python 2 compatibility otherwise
+            # later file writes will fail
+            f.seek(0, os.SEEK_END)
+
+            return ch != b'\n'
 
         with self._history_file("ab+") as hfile:
             if prefix_with_newline(hfile):


### PR DESCRIPTION
On Python 2.7 I see an IOError exception when writing to `history.txt` after the call to prefix_with_newline().

The original code works fine on 3.7.