### PR TITLE
Fixed PE hash format.

### DIFF
--- a/symstore/symstore.py
+++ b/symstore/symstore.py
@@ -62,7 +62,7 @@ def _pdb_hash(filename):
 def _pe_hash(file):
     pefile = pe.PEFile(file)
 
-    return "%X%X" % (pefile.TimeDateStamp, pefile.SizeOfImage)
+    return "%X%x" % (pefile.TimeDateStamp, pefile.SizeOfImage)
 
 
 def _image_type(file):


### PR DESCRIPTION
dbghelp uses SizeOfImage in lowercase.
I think SizeOfImage should be lowercase.

Wireshark's capture:
![image](https://user-images.githubusercontent.com/62534309/114590244-7925ac80-9cc3-11eb-832e-db73e523b278.png)
