### PR TITLE
Enable Compression on Windows OSes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/*.egg-info
+**/__pycache__

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,10 @@ This can lead to significant reduction of data that needs to be transferred whil
 
 The compression mode is activated with ``--compress`` or ``-z`` flag to ``symstore`` command line utility.
 
-Symstore uses the native ``gcab`` library via python bindings to compress data.
+On Windows OSes, symstore will just call the ``makecab.exe`` utility that is included
+in all version of Windows to perform the compression.
+
+On other OSes, Symstore uses the native ``gcab`` library via python bindings to compress data.
 The required packages must be available on the system for the compression mode to work.
 
 On Ubuntu 20.04 or 18.04, install following packages:

--- a/symstore/cab.py
+++ b/symstore/cab.py
@@ -35,7 +35,8 @@ def compress(src_path, dest_path):
         cab.add_folder(cab_folder)
 
         out_file = Gio.File.new_for_path(dest_path)
-        cab.write_simple(out_file.replace(None,
-                                      False,
-                                      Gio.FileCreateFlags.REPLACE_DESTINATION,
-                                      None))
+        cab.write_simple(
+                out_file.replace(None,
+                                 False,
+                                 Gio.FileCreateFlags.REPLACE_DESTINATION,
+                                 None))

--- a/symstore/cab.py
+++ b/symstore/cab.py
@@ -4,7 +4,7 @@ import os
 compression_supported = True
 
 if os.name == 'nt':
-    # Use built-in makecab CLI utility on Windows OSes (included in PATH on all Windows versions)
+    # Use built-in makecab CLI utility which is included in all Windows OSes
     import subprocess
 else:
     try:
@@ -21,7 +21,8 @@ else:
 def compress(src_path, dest_path):
     assert compression_supported
     if os.name == 'nt':
-        args = ['makecab', '/D', 'CompressionType=LZX', '/D', 'CompressionMemory=21', src_path, dest_path]
+        args = ['makecab', '/D', 'CompressionType=LZX',
+                '/D', 'CompressionMemory=21', src_path, dest_path]
         subprocess.run(args, check=True, capture_output=True)
     else:
         cab_file = GCab.File.new_with_file(os.path.basename(src_path),
@@ -35,6 +36,6 @@ def compress(src_path, dest_path):
 
         out_file = Gio.File.new_for_path(dest_path)
         cab.write_simple(out_file.replace(None,
-                                          False,
-                                          Gio.FileCreateFlags.REPLACE_DESTINATION,
-                                          None))
+                                      False,
+                                      Gio.FileCreateFlags.REPLACE_DESTINATION,
+                                      None))

--- a/symstore/cab.py
+++ b/symstore/cab.py
@@ -1,32 +1,40 @@
-from os import path
+import os
 
 # this flag is false on systems that don't provide gcab library
 compression_supported = True
 
-try:
-    import gi
-    gi.require_version('GCab', '1.0')
-    from gi.repository import GCab
-    from gi.repository import Gio
-except ValueError:
-    compression_supported = False
-except ImportError:
-    compression_supported = False
+if os.name == 'nt':
+    # Use built-in makecab CLI utility on Windows OSes (included in PATH on all Windows versions)
+    import subprocess
+else:
+    try:
+        import gi
+        gi.require_version('GCab', '1.0')
+        from gi.repository import GCab
+        from gi.repository import Gio
+    except ValueError:
+        compression_supported = False
+    except ImportError:
+        compression_supported = False
 
 
 def compress(src_path, dest_path):
     assert compression_supported
-    cab_file = GCab.File.new_with_file(path.basename(src_path),
-                                       Gio.File.new_for_path(src_path))
+    if os.name == 'nt':
+        args = ['makecab', '/D', 'CompressionType=LZX', '/D', 'CompressionMemory=21', src_path, dest_path]
+        subprocess.run(args, check=True, capture_output=True)
+    else:
+        cab_file = GCab.File.new_with_file(os.path.basename(src_path),
+                                           Gio.File.new_for_path(src_path))
 
-    cab_folder = GCab.Folder.new(GCab.Compression.MSZIP)
-    cab_folder.add_file(cab_file, False)
+        cab_folder = GCab.Folder.new(GCab.Compression.MSZIP)
+        cab_folder.add_file(cab_file, False)
 
-    cab = GCab.Cabinet.new()
-    cab.add_folder(cab_folder)
+        cab = GCab.Cabinet.new()
+        cab.add_folder(cab_folder)
 
-    out_file = Gio.File.new_for_path(dest_path)
-    cab.write_simple(out_file.replace(None,
-                                      False,
-                                      Gio.FileCreateFlags.REPLACE_DESTINATION,
-                                      None))
+        out_file = Gio.File.new_for_path(dest_path)
+        cab.write_simple(out_file.replace(None,
+                                          False,
+                                          Gio.FileCreateFlags.REPLACE_DESTINATION,
+                                          None))


### PR DESCRIPTION
Even though Windows has the actual official SymStore command, I find it useful to have a cross-platform variant of that tool for my cross-platform scripts. It's also very useful that it's a python package that I can just stick in my requirements.txt in my projects. However, your version of symstore doesn't allow you to compress PDB files when it's run on Windows OSes.

This PR fixes that. All versions of Windows come with a CLI utility called makecab.exe (it's in the PATH) that can perform the necessary compression. My changes call that utility with the correct args instead of trying to import GCab (only available on UNIX OSes).