### PR TITLE
Add portable pdb support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The `makecab.exe` utility normally is included by default in Windows installatio
 
 ## Change Log
 
+### 0.4.0 (TBD)
+
+* add support for Portable PDB files (used by .Net projects)
+
 ### 0.3.4 (6 December 2022)
 
 * adds support for transaction comments (`--comment` cli argument)

--- a/symstore/pdb.py
+++ b/symstore/pdb.py
@@ -1,8 +1,5 @@
-from __future__ import absolute_import
-
 import math
 import struct
-import binascii
 from symstore import fileio
 
 SIGNATURE = b"Microsoft C/C++ MSF 7.00\r\n\x1ADS\0\0\0"
@@ -155,7 +152,7 @@ class GUID:
         self.data4 = data4
 
     def __str__(self):
-        data4_str = binascii.hexlify(self.data4).decode("utf-8").upper()
+        data4_str = self.data4.hex().upper()
 
         return "%.8X%.4X%.4X%s" % \
                (self.data1, self.data2, self.data3, data4_str)

--- a/symstore/symstore.py
+++ b/symstore/symstore.py
@@ -40,16 +40,7 @@ PINGME_FILE = "pingme.txt"
 
 
 def _pdb_hash(pdbfile):
-    # figure out age string to be used in the hash string
-    if pdbfile.age is None:
-        # some pdb files does not have age,
-        # according to symstore.exe we should just
-        # skip adding the age to the hash string
-        age_str = ""
-    else:
-        age_str = "%x" % pdbfile.age
-
-    return "%s%s" % (pdbfile.guid, age_str)
+    return "%s%s" % (pdbfile.guid, pdbfile.age_str)
 
 
 def _pe_hash(pefile):


### PR DESCRIPTION
Fixes https://github.com/symstore/symstore/issues/29
Also cleans up a couple of backcompat things not needed with 3.5+ as the only supported versions.

Relevant docs:
 - Partition II, Chapter 23 of https://www.ecma-international.org/wp-content/uploads/ECMA-335_2nd_edition_december_2002.pdf
 - Official portable PDB docs: https://github.com/dotnet/runtime/blob/v7.0.5/docs/design/specs/PortablePdb-Metadata.md#standalone-debugging-metadata
 - https://github.com/dotnet/symstore/blob/9c9ef5d6c845826e433f70a29f4d80bf7108e451/docs/specs/SSQP_Key_Conventions.md#portable-pdb-signature